### PR TITLE
Get actual highlighted text.

### DIFF
--- a/Roam JSON.js
+++ b/Roam JSON.js
@@ -27,7 +27,7 @@ function cleanHtml(html) {
         .replace("<u>", "^^")
         .replace("</u>", "^^"); // Convert styles to markdown
     // TODO ZU.parseMarkup to find anchor tags? https://github.com/zotero/zotero/blob/4.0/chrome/content/zotero/xpcom/utilities.js#L525
-    cleanhtml = cleanhtml.replace(/([^+>]*)[^<]*(<a [^>]*(href="([^>^\"]*)")[^>]*>)([^<]+)(<\/a>[)])/gi, "$1___$2 ([$5]($4))"); // Convert anchors to markdown
+    cleanhtml = cleanhtml.replace(/([^+>]*)[^<]"*(<a [^>]*(href="([^>^\"]*)")[^>]*>)([^<]+)(<\/a>[)])/gi, "$1___$2 ([$5]($4))"); // Convert anchors to markdown
     cleanhtml = cleanhtml.replace(/<[^>]*>?/gm, ""); // Strip remaining tags
     // TODO retain soft linebreaks within the paragraph
     return cleanhtml;


### PR DESCRIPTION
Hi, first, thank for this.

The current version does not get the actual highlighted I extracted from Zotero. 
<img width="712" alt="Screenshot 2020-05-23 at 18 43 15" src="https://user-images.githubusercontent.com/12573521/82736952-45e1d400-9d25-11ea-984c-92141a963044.png">

I hack around and stumble upon a quick fix:
<img width="748" alt="Screenshot 2020-05-23 at 18 43 57" src="https://user-images.githubusercontent.com/12573521/82736969-5eea8500-9d25-11ea-9da6-7e62c8d4452e.png">

Maybe this will help.
